### PR TITLE
libftdi1.so.2 error fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@
 FROM ubuntu:jammy 
 ARG RELEASE_TYPE=STABLE
 
+# Preventing debconf errors
+ENV DEBIAN_FRONTEND=noninteractive
+
 # Install dependencies
 RUN set -eux; \
     apt-get update ; \
@@ -18,7 +21,7 @@ RUN set -eux; \
     openssl  \
     libx11-6 \
     libusb-1.0-0  \
-    libftdi1 \
+    libftdi1-2 \
     libexpat-dev  \
     libgl-dev  \
     libfreetype6 \


### PR DESCRIPTION
Fixed the problem of the missing “libftdi1.so.2” library and defined a non-interactive interface to avoid errors.